### PR TITLE
Iterate scripts to create build dir on first start

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "prettier": "prettier {*.*,**/*.*} --single-quote --write",
-    "start": "cp index.html build; concurrently \"rollup -c -w\" \"cd build; hot-server\""
+    "build": "rollup -c && cp index.html build",
+    "watch": "rollup -c -w",
+    "start": "npm run build; concurrently \"npm run watch\" \"cd build; hot-server\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
It was breaking on the first start, when `build` didn't exist. Now it first creates `build` (via Rollup), _then_ tries to copy the HTML into there.